### PR TITLE
Add custom user-agent support to parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ _(read more about the specification at http://ogp.me/)_
       "type": "video.movie",
       "image": "https://m.media-amazon.com/images/M/MV5BNGNhMDIzZTUtNTBlZi00MTRlLWFjM2ItYzViMjE3YzI5MjljXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_UY1200_CR97,0,630,1200_AL_.jpg",
       "description": """
-         Directed by Quentin Tarantino.  With John Travolta, Uma Thurman, 
-         Samuel L. Jackson, Bruce Willis. The lives of two mob hitmen, 
-         a boxer, a gangster and his wife, and a pair of diner bandits 
+         Directed by Quentin Tarantino.  With John Travolta, Uma Thurman,
+         Samuel L. Jackson, Bruce Willis. The lives of two mob hitmen,
+         a boxer, a gangster and his wife, and a pair of diner bandits
          intertwine in four tales of violence and redemption.
       """,
    }
@@ -51,5 +51,18 @@ You can pass a specific list of tags to `parse` function if you want:
       "title": "Pulp Fiction (1994) - IMDb",
    }
 ```
+
+You can also pass a custom user-agent header to be used when fetching the url,
+in the event that the site blocks generic python-requests user-agent strings:
+```python
+>>> import opengrapher
+>>> user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246"
+>>> opengrapher.parse('https://www.imdb.com/title/tt0110912', user_agent=user_agent)
+{
+   "url": "https://www.imdb.com/title/tt0110912",
+   "title": "Pulp Fiction (1994) - IMDb",
+}
+```
+
 
 > Note that all tags will be transformed to "og:{tag}" format, as it stated in opengraph notation

--- a/opengrapher/__init__.py
+++ b/opengrapher/__init__.py
@@ -23,8 +23,11 @@ def _parse_tag(soup, tag):
     return elem["content"]
 
 
-def parse(url, parse_tags=PARSE_TAGS):
-    r = requests.get(url)
+def parse(url, parse_tags=PARSE_TAGS, user_agent=None):
+    headers = {}
+    if user_agent is not None:
+        headers["user-agent"] = user_agent
+    r = requests.get(url, headers=headers)
     if not r.ok:
         raise BadResponse(r.status_code)
     if not r.content:


### PR DESCRIPTION
Certain sites will return a 403 Forbidden error when they detect the default python requests user-agent header. This change will allow a custom user-agent string to be passed to `parse()` to work around this issue.